### PR TITLE
Update SWarp to 2.41.5

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 export CFLAGS="${CFLAGS} -fcommon"
-cp "${BUILD_PREFIX}"/share/gnuconfig/config.* autoconf/
+if [ -d autoconf ]; then
+  cp "${BUILD_PREFIX}"/share/gnuconfig/config.* autoconf/
+fi
 
 ./configure --prefix=${PREFIX}
 make

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -7,6 +7,8 @@ if [ ! -f configure ] && [ -f autogen.sh ]; then
   ./autogen.sh
 fi
 
-./configure --prefix=${PREFIX}
+./configure --prefix=${PREFIX} \
+  --with-cfitsio-libdir=${PREFIX}/lib \
+  --with-cfitsio-incdir=${PREFIX}/include
 make
 make install

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -3,6 +3,9 @@ export CFLAGS="${CFLAGS} -fcommon"
 if [ -d autoconf ]; then
   cp "${BUILD_PREFIX}"/share/gnuconfig/config.* autoconf/
 fi
+if [ ! -f configure ] && [ -f autogen.sh ]; then
+  ./autogen.sh
+fi
 
 ./configure --prefix=${PREFIX}
 make

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "swarp" %}
-{% set version = "2.38.0" %}
+{% set version = "2.41.5" %}
 
 package:
   name: astromatic-{{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/astromatic/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
-  sha256: e95022547ff6f29387131818d3618d4bd7fc506eb56e37fea7ca96bf2b976d4c
+  sha256: 954cebb1e5b1b4f7791b9b38b4e0f07bb2233775a97d6254def5c24b6b5a7f31
 
 build:
   skip: true  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,6 +22,8 @@ requirements:
     - gnuconfig  # [unix]
     - libtool
     - make
+  host:
+    - cfitsio
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,10 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ stdlib("c") }}
+    - autoconf
+    - automake
     - gnuconfig  # [unix]
+    - libtool
     - make
 
 test:


### PR DESCRIPTION
This updates astromatic-swarp from 2.38.0 to 2.41.5 and refreshes the source checksum.

Co-Authored-By: Oz <oz-agent@warp.dev>